### PR TITLE
Add paciente to INSTALLED_APPS

### DIFF
--- a/app_pos/app_pos/settings.py
+++ b/app_pos/app_pos/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'paciente',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Summary
- include `paciente` in `INSTALLED_APPS`

## Testing
- `python app_pos/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_683f7f7388408332bbb93860b27ed349