### PR TITLE
Add basic auth and patient views

### DIFF
--- a/app_pos/app_pos/settings.py
+++ b/app_pos/app_pos/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'paciente',
 ]
 
 MIDDLEWARE = [

--- a/app_pos/app_pos/urls.py
+++ b/app_pos/app_pos/urls.py
@@ -15,8 +15,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('accounts/login/', auth_views.LoginView.as_view(), name='login'),
+    path('accounts/logout/', auth_views.LogoutView.as_view(next_page='login'), name='logout'),
+    path('pacientes/', include('paciente.urls')),
 ]

--- a/app_pos/paciente/admin.py
+++ b/app_pos/paciente/admin.py
@@ -1,3 +1,7 @@
 from django.contrib import admin
+from .models import Paciente
 
-# Register your models here.
+
+@admin.register(Paciente)
+class PacienteAdmin(admin.ModelAdmin):
+    list_display = ("nombre", "edad")

--- a/app_pos/paciente/forms.py
+++ b/app_pos/paciente/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from .models import Paciente
+
+
+class PacienteForm(forms.ModelForm):
+    class Meta:
+        model = Paciente
+        fields = ['nombre', 'edad']

--- a/app_pos/paciente/migrations/0001_initial.py
+++ b/app_pos/paciente/migrations/0001_initial.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Paciente',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('nombre', models.CharField(max_length=100)),
+                ('edad', models.PositiveIntegerField()),
+            ],
+        ),
+    ]

--- a/app_pos/paciente/models.py
+++ b/app_pos/paciente/models.py
@@ -1,3 +1,9 @@
 from django.db import models
 
-# Create your models here.
+
+class Paciente(models.Model):
+    nombre = models.CharField(max_length=100)
+    edad = models.PositiveIntegerField()
+
+    def __str__(self) -> str:
+        return self.nombre

--- a/app_pos/paciente/templates/paciente/crear.html
+++ b/app_pos/paciente/templates/paciente/crear.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Nuevo Paciente{% endblock %}
+{% block content %}
+<h1>Nuevo Paciente</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Guardar</button>
+</form>
+<a href="{% url 'paciente_list' %}">Volver a la lista</a>
+{% endblock %}

--- a/app_pos/paciente/templates/paciente/lista.html
+++ b/app_pos/paciente/templates/paciente/lista.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Pacientes{% endblock %}
+{% block content %}
+<h1>Pacientes</h1>
+<ul>
+{% for p in pacientes %}
+  <li>{{ p.nombre }} ({{ p.edad }})</li>
+{% empty %}
+  <li>No hay pacientes</li>
+{% endfor %}
+</ul>
+<a href="{% url 'paciente_crear' %}">Crear Paciente</a>
+{% endblock %}

--- a/app_pos/paciente/urls.py
+++ b/app_pos/paciente/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.list_pacientes, name='paciente_list'),
+    path('nuevo/', views.crear_paciente, name='paciente_crear'),
+]

--- a/app_pos/paciente/views.py
+++ b/app_pos/paciente/views.py
@@ -1,3 +1,23 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.contrib.auth.decorators import login_required
 
-# Create your views here.
+from .models import Paciente
+from .forms import PacienteForm
+
+
+@login_required
+def list_pacientes(request):
+    pacientes = Paciente.objects.all()
+    return render(request, 'paciente/lista.html', {'pacientes': pacientes})
+
+
+@login_required
+def crear_paciente(request):
+    if request.method == 'POST':
+        form = PacienteForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('paciente_list')
+    else:
+        form = PacienteForm()
+    return render(request, 'paciente/crear.html', {'form': form})

--- a/app_pos/templates/base.html
+++ b/app_pos/templates/base.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}POS Consulta{% endblock %}</title>
+</head>
+<body>
+{% if user.is_authenticated %}
+    <p>Bienvenido {{ user.username }} - <a href="{% url 'logout' %}">Logout</a></p>
+{% endif %}
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/app_pos/templates/registration/login.html
+++ b/app_pos/templates/registration/login.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Login</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- enable `paciente` app
- wire up login/logout routes and patient URLs
- add `Paciente` model and admin registration
- implement restricted patient list/create views
- add base and login templates
- add simple patient templates

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f7fc5f2c883328f8fa2deb967cf85