### PR TITLE
Fix calendar dropdown stacking

### DIFF
--- a/static/css/calendar.css
+++ b/static/css/calendar.css
@@ -90,6 +90,7 @@
 }
 
 .calendar-event {
+    position: relative;
     background: #f8faff;
     border-radius: 12px;
     border: 1px solid #dbe5f1;
@@ -184,10 +185,28 @@
     text-decoration: underline;
 }
 
+.calendar-event-actions {
+    position: relative;
+    z-index: 20;
+}
+
+.calendar-event--menu-open .calendar-event-actions {
+    z-index: 2050;
+}
+
 .calendar-event-actions .dropdown-menu {
     min-width: 220px;
     font-size: 0.9rem;
     padding: 0.5rem 0;
+    z-index: 1080;
+}
+
+.calendar-event--menu-open {
+    z-index: 2000;
+}
+
+.calendar-event--menu-open .calendar-event-actions .dropdown-menu {
+    z-index: 2100;
 }
 
 .calendar-event-actions .dropdown-item i {

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -735,6 +735,21 @@ function criarMenuAcoesCalendario(paciente) {
     patient: paciente,
   }));
 
+  const toggleCalendarEventMenuState = (action) => {
+    const calendarEventElement = dropdownWrapper.closest('.calendar-event');
+    if (calendarEventElement) {
+      calendarEventElement.classList[action]('calendar-event--menu-open');
+    }
+  };
+
+  dropdownWrapper.addEventListener('show.bs.dropdown', () => {
+    toggleCalendarEventMenuState('add');
+  });
+
+  dropdownWrapper.addEventListener('hidden.bs.dropdown', () => {
+    toggleCalendarEventMenuState('remove');
+  });
+
   dropdownWrapper.appendChild(toggle);
   dropdownWrapper.appendChild(menu);
 


### PR DESCRIPTION
## Summary
- make calendar event cards establish a positioning context for dropdown menus
- elevate an event card and its dropdown while the action menu is open so it renders above neighbors and the card itself

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'environ')*

------
https://chatgpt.com/codex/tasks/task_e_68cf4605546c8332ae235a87fbc9731d