### PR TITLE
Disable view toggles until initial load completes

### DIFF
--- a/templates/home/home.html
+++ b/templates/home/home.html
@@ -144,11 +144,11 @@
             <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2" id="patients-view-switcher">
                 <h2 class="fs-5 mb-0 text-secondary">Visão de Pacientes</h2>
                 <div class="btn-group btn-group-sm" role="group" aria-label="Alternar visualização de pacientes">
-                    <button type="button" class="btn btn-outline-primary active" id="view-toggle-list">
+                    <button type="button" class="btn btn-outline-primary active" id="view-toggle-list" disabled aria-disabled="true">
                         <i class="bi bi-card-list me-1"></i>
                         Lista
                     </button>
-                    <button type="button" class="btn btn-outline-primary" id="view-toggle-calendar">
+                    <button type="button" class="btn btn-outline-primary" id="view-toggle-calendar" disabled aria-disabled="true">
                         <i class="bi bi-calendar3 me-1"></i>
                         Calendário
                     </button>


### PR DESCRIPTION
## Summary
- disable the patient view toggle buttons until the initial data load finishes
- add helpers in home.js to manage toggle interactivity after page init

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0a1e2958483329372b3c4ff23817d